### PR TITLE
Updated to toJSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ By encapsulating the original error, its context, and any additional information
 
 By using the HierarchicalError class, developers can maintain the integrity of the error message while preventing log clutter and improving the clarity of error reports, ultimately making troubleshooting much easier and more effective.
 
+Another solution might be to use JavaScript’s Error class’s cause option as described [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error#differentiate_between_similar_errors). Similar features are supported by other languages. However, this doesn’t support adding extra context to the error, without some type manipulation, and would require additional logic to extract the cause(s) for the logger when caught, which could be better encapsulated into a new type. This also wouldn’t allow for adding further explicit context, such as an indication of the logging level or HTTP response code for the error.
+
 [Read more](https://paulgrenyer.blogspot.com/2025/01/hierarchical-error-reducing-log.html)
 
 ## Install

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ const getController = () => {
         callService();
     } catch (error: any) {
         if (isHierarchicalError(error)) {
-            log(error.message, error.toContextJson());
+            log(error.message, error.toJSON());
         } else {
             log(error);
         }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
         "postbuild": "cpy '**/*' '!**/*.ts' '!**/*.tsx' ../dist/ --cwd=src/ --no-overwrite --parents",
         "test": "npx jest --coverage --detectOpenHandles",
         "format": "prettier --write 'src/**/*.ts' 'test/**/*.ts' './*.json' './*.js' './*.mjs'",
-        "lint": "eslint --fix",
+        "lint": "npm run format && eslint --fix",
         "prepare": "husky"
     },
     "repository": {

--- a/src/error-to-json.ts
+++ b/src/error-to-json.ts
@@ -1,5 +1,8 @@
 export const errorToJson = (error: unknown) => {
-    if (error instanceof Error) {
+    if (Object.prototype.hasOwnProperty.call(error, 'toJSON')) {
+        const e = error as { toJSON(): void };
+        return e.toJSON();
+    } else if (error instanceof Error) {
         const e = error as Error;
         return { name: e.name, message: e.message, stack: e.stack, cause: e.cause };
     }

--- a/src/error-to-json.ts
+++ b/src/error-to-json.ts
@@ -1,6 +1,8 @@
-export const errorToJson = (error: unknown) => {
+import { HierarchicalContextItemOrAny } from './hierarchical-context-item';
+
+export const errorToJson = (error: unknown): HierarchicalContextItemOrAny => {
     if (Object.prototype.hasOwnProperty.call(error, 'toJSON')) {
-        const e = error as { toJSON(): void };
+        const e = error as { toJSON(): HierarchicalContextItemOrAny };
         return e.toJSON();
     } else if (error instanceof Error) {
         const e = error as Error;

--- a/src/error-to-json.ts
+++ b/src/error-to-json.ts
@@ -1,0 +1,7 @@
+export const errorToJson = (error: unknown) => {
+    if (error instanceof Error) {
+        const e = error as Error;
+        return { name: e.name, message: e.message, stack: e.stack, cause: e.cause };
+    }
+    return `${error}`;
+};

--- a/src/hierarchical-context-item.ts
+++ b/src/hierarchical-context-item.ts
@@ -1,0 +1,10 @@
+export interface HierarchicalContextItem {
+    message: string;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    cause?: HierarchicalContextItem | any;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    context?: any;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type HierarchicalContextItemOrAny = HierarchicalContextItem | any;

--- a/src/hierarchical-error.ts
+++ b/src/hierarchical-error.ts
@@ -1,12 +1,5 @@
 import { errorToJson } from './error-to-json';
-
-interface HierarchicalContextItem {
-    message: string;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    cause?: HierarchicalContextItem | any;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    context?: any;
-}
+import { HierarchicalContextItem } from './hierarchical-context-item';
 
 export class HierarchicalError extends Error {
     readonly cause;

--- a/src/hierarchical-error.ts
+++ b/src/hierarchical-error.ts
@@ -1,3 +1,5 @@
+import { errorToJson } from './error-to-json';
+
 interface HierarchicalContextItem {
     message: string;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -20,7 +22,7 @@ export class HierarchicalError extends Error {
     toContextJson = (): HierarchicalContextItem => ({
         message: this.message,
         context: this.context,
-        cause: isHierarchicalError(this.cause) ? this.cause.toContextJson() : this.cause,
+        cause: isHierarchicalError(this.cause) ? this.cause.toContextJson() : errorToJson(this.cause),
     });
 
     toJSON = () => this.toContextJson();

--- a/src/hierarchical-error.ts
+++ b/src/hierarchical-error.ts
@@ -19,13 +19,11 @@ export class HierarchicalError extends Error {
         this.context = context;
     }
 
-    toContextJson = (): HierarchicalContextItem => ({
+    toJSON = (): HierarchicalContextItem => ({
         message: this.message,
         context: this.context,
-        cause: isHierarchicalError(this.cause) ? this.cause.toContextJson() : errorToJson(this.cause),
+        cause: isHierarchicalError(this.cause) ? this.cause.toJSON() : errorToJson(this.cause),
     });
-
-    toJSON = () => this.toContextJson();
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/hierarchical-error.ts
+++ b/src/hierarchical-error.ts
@@ -11,7 +11,7 @@ export class HierarchicalError extends Error {
     readonly context;
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    constructor(message: string, context?: any, cause?: any) {
+    constructor(message: string, context?: any, cause?: HierarchicalContextItem | any) {
         super(message);
         this.cause = cause;
         this.context = context;

--- a/test/error-to-json.test.ts
+++ b/test/error-to-json.test.ts
@@ -1,0 +1,35 @@
+import { errorToJson } from '../src/error-to-json';
+
+describe('Error To Json', () => {
+    it('should return as string', () => {
+        const result = errorToJson('Error!');
+        expect(result).toEqual('Error!');
+    });
+
+    it('should return as Error object', () => {
+        const result = errorToJson(new Error('Error!'));
+        expect(result).toEqual({
+            cause: undefined,
+            message: 'Error!',
+            name: 'Error',
+            stack: expect.any(String),
+        });
+    });
+
+    class MyError extends Error {
+        constructor(message: string) {
+            super(message);
+        }
+
+        toJSON = () => ({
+            message: this.message,
+        });
+    }
+
+    it("should return use object's toJSON", () => {
+        const result = errorToJson(new MyError('Error!'));
+        expect(result).toEqual({
+            message: 'Error!',
+        });
+    });
+});

--- a/test/error-to-json.test.ts
+++ b/test/error-to-json.test.ts
@@ -22,14 +22,14 @@ describe('Error To Json', () => {
         }
 
         toJSON = () => ({
-            message: this.message,
+            message: `toJSON: ${this.message}`,
         });
     }
 
     it("should return use object's toJSON", () => {
         const result = errorToJson(new MyError('Error!'));
         expect(result).toEqual({
-            message: 'Error!',
+            message: 'toJSON: Error!',
         });
     });
 });

--- a/test/hierachical-error.test.ts
+++ b/test/hierachical-error.test.ts
@@ -22,14 +22,13 @@ describe('Hierarchical Error', () => {
     };
 
     it('should have correct output', () => {
-        expect.assertions(3);
+        expect.assertions(2);
 
         try {
             callService();
         } catch (error: any) {
             const hierarchicalError = error as HierarchicalError;
             expect(hierarchicalError.message).toEqual('Service failed.');
-            expect(hierarchicalError.toJSON()).toEqual(context);
             expect(hierarchicalError.toJSON()).toEqual(context);
         }
     });

--- a/test/hierachical-error.test.ts
+++ b/test/hierachical-error.test.ts
@@ -29,7 +29,7 @@ describe('Hierarchical Error', () => {
         } catch (error: any) {
             const hierarchicalError = error as HierarchicalError;
             expect(hierarchicalError.message).toEqual('Service failed.');
-            expect(hierarchicalError.toContextJson()).toEqual(context);
+            expect(hierarchicalError.toJSON()).toEqual(context);
             expect(hierarchicalError.toJSON()).toEqual(context);
         }
     });

--- a/test/hierachical-error.test.ts
+++ b/test/hierachical-error.test.ts
@@ -4,7 +4,12 @@ import { HierarchicalError, isHierarchicalError } from './../src/hierarchical-er
 describe('Hierarchical Error', () => {
     const context = {
         cause: {
-            cause: new Error('Something went wrong!'),
+            cause: {
+                cause: undefined,
+                message: 'Something went wrong!',
+                name: 'Error',
+                stack: expect.any(String),
+            },
             context: {
                 someContext: 'the url we called',
             },
@@ -16,7 +21,7 @@ describe('Hierarchical Error', () => {
         message: 'Service failed.',
     };
 
-    it('should have corect output', () => {
+    it('should have correct output', () => {
         expect.assertions(3);
 
         try {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
         // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
         /* Language and Environment */
-        "target": "es2019" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
+        "target": "es2022" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
         // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
         // "jsx": "preserve",                                /* Specify what JSX code is generated. */
         // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */


### PR DESCRIPTION
Frank complained that:

"why are the methods called toJSON and toContextJson when they do not return JSON text but just regular JS objects?"

He had a point (don't tell him) so I fixed it.

There's now only one function, toJSON, which returns valid JSON ready for stringification. 
